### PR TITLE
Remove DataTable scritps from Index.html

### DIFF
--- a/assets/scripts/config.js
+++ b/assets/scripts/config.js
@@ -2,7 +2,8 @@
 
 const config = {
   apiOrigins: {
-    production: 'https://guarded-fjord-43518.herokuapp.com/'
+    development: 'http://localhost:4741',
+    production: 'https://guarded-fjord-43518.herokuapp.com'
   }
 }
 

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -3,6 +3,7 @@
 const setAPIOrigin = require('../../lib/set-api-origin')
 const config = require('./config')
 const authEvents = require('./events')
+const dt = require('datatables.net')
 
 $(() => {
   setAPIOrigin(location, config)

--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
       <!-- Do not add `link` tags unless you know what you are doing -->
       <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
       <link href="https://fonts.googleapis.com/css?family=Open+Sans|Play" rel="stylesheet">
-      <link href="https://cdn.datatables.net/1.10.15/css/dataTables.bootstrap.min.css" rel="stylesheet">
+      <!-- <link href="https://cdn.datatables.net/1.10.15/css/dataTables.bootstrap.min.css" rel="stylesheet"> -->
       <!-- Do not add `script` tags unless you know what you are doing -->
       <script src="https://use.fontawesome.com/b9279fc81b.js"></script>
       <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>
       <script src="public/application.js" type="text/javascript" charset="utf-8" defer></script>
-      <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js" type="text/javascript" charset="utf-8" defer></script>
+      <!-- <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js" type="text/javascript" charset="utf-8" defer></script> -->
     </head>
     <body class="container-fluid">
     <div class="header">

--- a/lib/set-api-origin.js
+++ b/lib/set-api-origin.js
@@ -27,7 +27,7 @@ const setAPIOrigin = (location, config) => {
       const port = +('GA'.split('').reduce((p, c) =>
         p + c.charCodeAt().toString(16), '')
       )
-      config.apiOrigin = `https://guarded-fjord-43518.herokuapp.com/`
+      config.apiOrigin = `https://guarded-fjord-43518.herokuapp.com`
     }
   } else {
     config.apiOrigin = config.apiOrigins.production


### PR DESCRIPTION
Removes the link to the Datatable JS and CSS files in Index.html.
Files are NPM installed and required in index.js.